### PR TITLE
修复待签名字符串错误导致验证不成功问题和返回码错误问题

### DIFF
--- a/Samples/Topic/http_server_sample.php
+++ b/Samples/Topic/http_server_sample.php
@@ -95,7 +95,7 @@ $pass = verify($stringToSign, $signature, $publicKey);
 if (!$pass)
 {
     error_log("verify signature fail");
-    http_response_code(400);
+    http_response_code(403);
     return;
 }
 
@@ -106,7 +106,7 @@ error_log($content);
 if (!empty($contentMd5) && $contentMd5 != base64_encode(md5($content)))
 {
     error_log("md5 mismatch");
-    http_response_code(401);
+    http_response_code(500);
     return;
 }
 
@@ -118,7 +118,7 @@ echo "MessageId: " . $msg->MessageId . "\n";
 echo "MessageMD5: " . $msg->MessageMD5 . "\n";
 echo "Message: " . $msg->Message . "\n";
 echo "______________________________________________________\n";
-http_response_code(200);
+http_response_code(204);
 
 
 ?>

--- a/Samples/Topic/http_server_sample.php
+++ b/Samples/Topic/http_server_sample.php
@@ -32,7 +32,18 @@ if (!function_exists('getallheaders'))
        {
            if (substr($name, 0, 5) == 'HTTP_')
            {
-               $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+               if (substr($name, 5, 11) == 'CONTENT_MD5')
+               {
+                   $headers['Content-md5'] = $value;
+               }
+               else if (substr($name, 5, 5) == 'X_MNS')
+               {
+                   $headers[str_replace(' ', '-', strtolower(str_replace('_', ' ', substr($name, 5))))] = $value;
+               }
+               else
+               {
+                   $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+               }
            }
        }
        return $headers;


### PR DESCRIPTION
### 待签名字符串错误问题。
1. 因为$_SERVER['HTTP_CONTENT_MD5']需要改为$headers("Content-md5"=>"XXX")格式，直接使用ucwords(strtolower())会成为Content-Md5，导致后面代码$contentMd5无法取得数组内容。
2. 因为”x-mns..."开头的字段都为小写，不能使用ucwords()处理。
### 返回码错误问题
1. 根据“消息通知功能说明”文档，若确认成功，返回204。若请求签名认证不过，返回403。若任何其他错误，返回500。