### PR TITLE
修复报错

### DIFF
--- a/AliyunMNS/Responses/BatchDeleteMessageResponse.php
+++ b/AliyunMNS/Responses/BatchDeleteMessageResponse.php
@@ -38,7 +38,7 @@ class BatchDeleteMessageResponse extends BaseResponse
                 if ($xmlReader->nodeType == \XMLReader::ELEMENT) {
                     switch ($xmlReader->name) {
                     case Constants::ERROR:
-                        $this->parseNormalErrorResponse($xmlReader);
+                        $this->parseNormalErrorResponse($xmlReader, $statusCode, $exception);
                         break;
                     default: // case Constants::Messages
                         $this->parseBatchDeleteErrorResponse($xmlReader);
@@ -71,7 +71,7 @@ class BatchDeleteMessageResponse extends BaseResponse
         throw $ex;
     }
 
-    private function parseNormalErrorResponse($xmlReader)
+    private function parseNormalErrorResponse($xmlReader, $statusCode, $exception)
     {
         $result = XMLParser::parseNormalError($xmlReader);
 

--- a/AliyunMNS/Responses/BatchSendMessageResponse.php
+++ b/AliyunMNS/Responses/BatchSendMessageResponse.php
@@ -62,7 +62,7 @@ class BatchSendMessageResponse extends BaseResponse
                 if ($xmlReader->nodeType == \XMLReader::ELEMENT) {
                     switch ($xmlReader->name) {
                     case Constants::ERROR:
-                        $this->parseNormalErrorResponse($xmlReader);
+                        $this->parseNormalErrorResponse($xmlReader, $statusCode, $exception);
                         break;
                     default: // case Constants::Messages
                         $this->parseBatchSendErrorResponse($xmlReader);
@@ -95,7 +95,7 @@ class BatchSendMessageResponse extends BaseResponse
         throw $ex;
     }
 
-    private function parseNormalErrorResponse($xmlReader)
+    private function parseNormalErrorResponse($xmlReader, $statusCode, $exception)
     {
         $result = XMLParser::parseNormalError($xmlReader);
         if ($result['Code'] == Constants::QUEUE_NOT_EXIST)


### PR DESCRIPTION
方法使用了未定义的变量, 此变量应由调用方传递.

导致的问题:
在出现异常行为时会走到这里. 如向一个不存在的 mns 队列发送消息