### PR TITLE
避免使用动态属性

### DIFF
--- a/AliyunMNS/Http/HttpClient.php
+++ b/AliyunMNS/Http/HttpClient.php
@@ -46,8 +46,7 @@ class HttpClient
         $this->requestTimeout = $config->getRequestTimeout();
         $this->connectTimeout = $config->getConnectTimeout();
         $this->securityToken = $securityToken;
-        $this->endpoint = $endPoint;
-        $this->parseEndpoint();
+        $this->parseEndpoint($endPoint);
     }
 
     public function getRegion()
@@ -61,9 +60,9 @@ class HttpClient
     }
 
     // This function is for SDK internal use
-    private function parseEndpoint()
+    private function parseEndpoint($endPoint)
     {
-        $pieces = explode("//", $this->endpoint);
+        $pieces = explode("//", $endPoint);
         $host = end($pieces);
 
         $host_pieces = explode(".", $host);


### PR DESCRIPTION
动态属性在 PHP8.2 中会触发 Deprecated Error