### PR TITLE
更新和优化阿里云 MNS SDK，以提高其稳定性和兼容性

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+vendor
+composer.lock
+logs
+doc
+output
+.idea
+.buildpath
+.project
+.settings

--- a/AliyunMNS/Constants.php
+++ b/AliyunMNS/Constants.php
@@ -13,6 +13,9 @@ class Constants
     const AUTHORIZATION = "Authorization";
     const MNS = "MNS";
 
+    const ALIYUN_AK_ENV_KEY = "ALIBABA_CLOUD_ACCESS_KEY_ID";
+    const ALIYUN_SK_ENV_KEY = "ALIBABA_CLOUD_ACCESS_KEY_SECRET";
+
     const CONTENT_LENGTH = "Content-Length";
     const CONTENT_TYPE = "Content-Type";
     const SECURITY_TOKEN = "security-token";

--- a/AliyunMNS/Model/QueueAttributes.php
+++ b/AliyunMNS/Model/QueueAttributes.php
@@ -15,7 +15,7 @@ class QueueAttributes
     private $messageRetentionPeriod;
     private $visibilityTimeout;
     private $pollingWaitSeconds;
-    private $LoggingEnabled;
+    private $loggingEnabled;
 
     # the following attributes cannot be changed
     private $queueName;

--- a/AliyunMNS/Model/SendMessageRequestItem.php
+++ b/AliyunMNS/Model/SendMessageRequestItem.php
@@ -4,7 +4,9 @@ namespace AliyunMNS\Model;
 use AliyunMNS\Constants;
 use AliyunMNS\Traits\MessagePropertiesForSend;
 
-// this class is used for BatchSend
+/**
+ * this class is recommended for sendMessage and batchSendMessage.
+ */
 class SendMessageRequestItem
 {
     use MessagePropertiesForSend;

--- a/AliyunMNS/Model/TopicAttributes.php
+++ b/AliyunMNS/Model/TopicAttributes.php
@@ -12,7 +12,7 @@ class TopicAttributes
 {
     private $maximumMessageSize;
     private $messageRetentionPeriod;
-    private $LoggingEnabled;
+    private $loggingEnabled;
 
     # the following attributes cannot be changed
     private $topicName;

--- a/AliyunMNS/Requests/BatchSendMessageRequest.php
+++ b/AliyunMNS/Requests/BatchSendMessageRequest.php
@@ -22,6 +22,9 @@ class BatchSendMessageRequest extends BaseRequest
         $this->base64 = $base64;
     }
 
+    /**
+     * @internal internal method, not for public use.
+     */
     public function setBase64($base64)
     {
         $this->base64 = $base64;

--- a/AliyunMNS/Requests/ListQueueRequest.php
+++ b/AliyunMNS/Requests/ListQueueRequest.php
@@ -43,7 +43,7 @@ class ListQueueRequest extends BaseRequest
 
     public function setPrefix($prefix)
     {
-        $this->prefis = $prefix;
+        $this->prefix = $prefix;
         if ($prefix != NULL)
         {
             $this->setHeader("x-mns-prefix", $prefix);

--- a/AliyunMNS/Requests/ListSubscriptionRequest.php
+++ b/AliyunMNS/Requests/ListSubscriptionRequest.php
@@ -54,7 +54,7 @@ class ListSubscriptionRequest extends BaseRequest
 
     public function setPrefix($prefix)
     {
-        $this->prefis = $prefix;
+        $this->prefix = $prefix;
         if ($prefix != NULL)
         {
             $this->setHeader("x-mns-prefix", $prefix);

--- a/AliyunMNS/Requests/ListTopicRequest.php
+++ b/AliyunMNS/Requests/ListTopicRequest.php
@@ -43,7 +43,7 @@ class ListTopicRequest extends BaseRequest
 
     public function setPrefix($prefix)
     {
-        $this->prefis = $prefix;
+        $this->prefix = $prefix;
         if ($prefix != NULL)
         {
             $this->setHeader("x-mns-prefix", $prefix);

--- a/AliyunMNS/Requests/PublishBase64MessageRequest.php
+++ b/AliyunMNS/Requests/PublishBase64MessageRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AliyunMNS\Requests;
+
+class PublishBase64MessageRequest extends PublishMessageRequest
+{
+    public function __construct($messageBody, $messageTag = NULL, $messageAttributes = NULL)
+    {
+        parent::__construct(NULL, $messageTag, $messageAttributes);
+
+        $this->messageBody = base64_encode($messageBody);
+    }
+}

--- a/AliyunMNS/Requests/SendMessageRequest.php
+++ b/AliyunMNS/Requests/SendMessageRequest.php
@@ -26,6 +26,9 @@ class SendMessageRequest extends BaseRequest
         $this->base64 = $base64;
     }
 
+    /**
+     * @internal internal method, not for public use.
+     */
     public function setBase64($base64)
     {
         $this->base64 = $base64;

--- a/AliyunMNS/Requests/SetSubscriptionAttributeRequest.php
+++ b/AliyunMNS/Requests/SetSubscriptionAttributeRequest.php
@@ -8,6 +8,8 @@ use AliyunMNS\Model\UpdateSubscriptionAttributes;
 class SetSubscriptionAttributeRequest extends BaseRequest
 {
 
+    private $attributes;
+
     public function __construct(UpdateSubscriptionAttributes $attributes = NULL)
     {
         parent::__construct('put', 'topics/' . $attributes->getTopicName() . '/subscriptions/' . $attributes->getSubscriptionName() . '?metaoverride=true');

--- a/AliyunMNS/Responses/BatchDeleteMessageResponse.php
+++ b/AliyunMNS/Responses/BatchDeleteMessageResponse.php
@@ -38,7 +38,7 @@ class BatchDeleteMessageResponse extends BaseResponse
                 if ($xmlReader->nodeType == \XMLReader::ELEMENT) {
                     switch ($xmlReader->name) {
                     case Constants::ERROR:
-                        $this->parseNormalErrorResponse($xmlReader);
+                        $this->parseNormalErrorResponse($statusCode, $xmlReader, $exception);
                         break;
                     default: // case Constants::Messages
                         $this->parseBatchDeleteErrorResponse($xmlReader);
@@ -71,7 +71,7 @@ class BatchDeleteMessageResponse extends BaseResponse
         throw $ex;
     }
 
-    private function parseNormalErrorResponse($xmlReader)
+    private function parseNormalErrorResponse($statusCode, $xmlReader, $exception = NULL)
     {
         $result = XMLParser::parseNormalError($xmlReader);
 

--- a/AliyunMNS/Responses/BatchSendMessageResponse.php
+++ b/AliyunMNS/Responses/BatchSendMessageResponse.php
@@ -62,7 +62,7 @@ class BatchSendMessageResponse extends BaseResponse
                 if ($xmlReader->nodeType == \XMLReader::ELEMENT) {
                     switch ($xmlReader->name) {
                     case Constants::ERROR:
-                        $this->parseNormalErrorResponse($xmlReader);
+                        $this->parseNormalErrorResponse($statusCode, $xmlReader, $exception);
                         break;
                     default: // case Constants::Messages
                         $this->parseBatchSendErrorResponse($xmlReader);
@@ -95,7 +95,7 @@ class BatchSendMessageResponse extends BaseResponse
         throw $ex;
     }
 
-    private function parseNormalErrorResponse($xmlReader)
+    private function parseNormalErrorResponse($statusCode, $xmlReader, $exception = NULL)
     {
         $result = XMLParser::parseNormalError($xmlReader);
         if ($result['Code'] == Constants::QUEUE_NOT_EXIST)

--- a/AliyunMNS/Responses/MnsPromise.php
+++ b/AliyunMNS/Responses/MnsPromise.php
@@ -1,6 +1,7 @@
 <?php
 namespace AliyunMNS\Responses;
 
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
 use AliyunMNS\Responses\BaseResponse;
 use AliyunMNS\Exception\MnsException;
@@ -38,7 +39,7 @@ class MnsPromise
             }
         } catch (TransferException $e) {
             $message = $e->getMessage();
-            if ($e->hasResponse()) {
+            if ($e instanceof RequestException && $e->hasResponse()) {
                 $message = $e->getResponse()->getBody();
             }
             throw new MnsException($e->getCode(), $message);

--- a/README.md
+++ b/README.md
@@ -29,7 +29,23 @@ composer install
 
 *Note: php version>=5.5.0, and xml extension of php is required.*
 
-## Samples
+## Run the Samples
 
-[Queue Sample](https://github.com/aliyun/aliyun-mns-php-sdk/blob/master/Samples/Queue/CreateQueueAndSendMessage.php)
+[Queue Sample](https://github.com/aliyun/aliyun-mns-php-sdk/blob/master/Samples/Queue/CreateQueueAndSendMessage.php)  
 [Topic Sample](https://github.com/aliyun/aliyun-mns-php-sdk/blob/master/Samples/Topic/CreateTopicAndPublishMessage.php) 
+
+The basic steps are:
+
+1. Set AliCloud AK/SK In Env, please see: [configure-the-alibaba-cloud-accesskey-environment](https://help.aliyun.com/zh/sdk/developer-reference/configure-the-alibaba-cloud-accesskey-environment-variable-on-linux-macos-and-windows-systems)
+2. Run (In the SDK root directory):
+   - `CreateQueueAndSendMessage.php` : Set the `Endpoint` at the bottom and Run `php Samples/Queue/CreateQueueAndSendMessage.php`.
+   - `CreateTopicAndPushMessageToQueue.php` : Set the `Endpoint` at the bottom and Run `Samples/Topic/CreateTopicAndPushMessageToQueue.php`.
+   - `CreateTopicAndPublishMessage.php` : Set the `Endpoint`, `ip` and `port` at the bottom and Run `Samples/Topic/CreateTopicAndPublishMessage.php`.
+   - `TopicSubscribe.php` : Set the `Endpoint`, `region` and `accountId` at the bottom and Run `Samples/Topic/TopicSubscribe.php`.
+
+## Run the Tests
+
+The basic steps are:
+
+1. Set AliCloud AK/SK/Endpoint In `Tests/aliyun-mns.ini`.
+2. In the SDK root directory, run `vendor/bin/phpunit`.

--- a/Samples/Common.php
+++ b/Samples/Common.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Samples;
+
+if (is_file(__DIR__ . '/../autoload.php')) {
+    require_once __DIR__ . '/../autoload.php';
+}
+if (is_file(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+}

--- a/Samples/Queue/CreateQueueAndSendMessage.php
+++ b/Samples/Queue/CreateQueueAndSendMessage.php
@@ -1,6 +1,9 @@
 <?php
 
+require_once __DIR__ . '/../Common.php';
+
 use AliyunMNS\Client;
+use AliyunMNS\Constants;
 use AliyunMNS\Model\SendMessageRequestItem;
 use AliyunMNS\Requests\BatchReceiveMessageRequest;
 use AliyunMNS\Requests\SendMessageRequest;
@@ -194,13 +197,18 @@ class CreateQueueAndSendMessage
     }
 }
 
-$accessId = "";
-$accessKey = "";
+$accessId = getenv(Constants::ALIYUN_AK_ENV_KEY);
+$accessKey = getenv(Constants::ALIYUN_SK_ENV_KEY);
 $endPoint = "";
 
-if (empty($accessId) || empty($accessKey) || empty($endPoint))
+if (empty($accessId) || empty($accessKey))
 {
-    echo "Must Provide AccessId/AccessKey/EndPoint to Run the Example. \n";
+    echo "Must Set AccessId/AccessKey In Env to Run the Example. \n";
+    return;
+}
+
+if (empty($endPoint)) {
+    echo "Must Provide EndPoint to Run the Example. \n";
     return;
 }
 

--- a/Samples/Topic/CreateTopicAndPublishMessage.php
+++ b/Samples/Topic/CreateTopicAndPublishMessage.php
@@ -1,6 +1,9 @@
 <?php
 
+require_once __DIR__ . '/../Common.php';
+
 use AliyunMNS\Client;
+use AliyunMNS\Constants;
 use AliyunMNS\Model\SubscriptionAttributes;
 use AliyunMNS\Requests\PublishMessageRequest;
 use AliyunMNS\Requests\CreateTopicRequest;
@@ -105,15 +108,20 @@ class CreateTopicAndPublishMessage
     }
 }
 
-$accessId = "";
-$accessKey = "";
+$accessId = getenv(Constants::ALIYUN_AK_ENV_KEY);
+$accessKey = getenv(Constants::ALIYUN_SK_ENV_KEY);
 $endPoint = "";
 $ip = ""; //公网IP
 $port = "8000";
 
-if (empty($accessId) || empty($accessKey) || empty($endPoint))
+if (empty($accessId) || empty($accessKey))
 {
-    echo "Must Provide AccessId/AccessKey/EndPoint to Run the Example. \n";
+    echo "Must Set AccessId/AccessKey In Env to Run the Example. \n";
+    return;
+}
+
+if (empty($endPoint) || empty($ip) || empty($port)) {
+    echo "Must Provide EndPoint/IP/Port to Run the Example. \n";
     return;
 }
 

--- a/Samples/Topic/CreateTopicAndPushMessageToQueue.php
+++ b/Samples/Topic/CreateTopicAndPushMessageToQueue.php
@@ -1,6 +1,9 @@
 <?php
 
+require_once __DIR__ . '/../Common.php';
+
 use AliyunMNS\Client;
+use AliyunMNS\Constants;
 use AliyunMNS\Exception\MessageNotExistException;
 use AliyunMNS\Model\SubscriptionAttributes;
 use AliyunMNS\Requests\PublishBase64MessageRequest;
@@ -132,12 +135,18 @@ class CreateTopicAndPushMessageToQueue
     }
 }
 
-$accessId = "";
-$accessKey = "";
+$accessId = getenv(Constants::ALIYUN_AK_ENV_KEY);
+$accessKey = getenv(Constants::ALIYUN_SK_ENV_KEY);
 $endPoint = "";
 
-if (empty($accessId) || empty($accessKey) || empty($endPoint)) {
-    echo "Must Provide AccessId/AccessKey/EndPoint to Run the Example. \n";
+if (empty($accessId) || empty($accessKey))
+{
+    echo "Must Set AccessId/AccessKey In Env to Run the Example. \n";
+    return;
+}
+
+if (empty($endPoint)) {
+    echo "Must Provide EndPoint to Run the Example. \n";
     return;
 }
 

--- a/Samples/Topic/CreateTopicAndPushMessageToQueue.php
+++ b/Samples/Topic/CreateTopicAndPushMessageToQueue.php
@@ -3,6 +3,7 @@
 use AliyunMNS\Client;
 use AliyunMNS\Exception\MessageNotExistException;
 use AliyunMNS\Model\SubscriptionAttributes;
+use AliyunMNS\Requests\PublishBase64MessageRequest;
 use AliyunMNS\Requests\PublishMessageRequest;
 use AliyunMNS\Requests\CreateTopicRequest;
 use AliyunMNS\Requests\CreateQueueRequest;
@@ -64,16 +65,29 @@ class CreateTopicAndPushMessageToQueue
 
         // 4. send message
         $messageBody = "test";
-        $request = new PublishMessageRequest(base64_encode($messageBody));
+        // publish raw string message
+        $request = new PublishMessageRequest($messageBody);
         try {
             $res = $topic->publishMessage($request);
-            echo "MessagePublished! \n";
+            echo "RawMessagePublished! \n";
         } catch (MnsException $e) {
-            echo "PublishMessage Failed: " . $e;
+            echo "PublishRawMessage Failed: " . $e;
+            return;
+        }
+
+        // publish base64 encoded message
+        $request = new PublishBase64MessageRequest($messageBody);
+        try {
+            $res = $topic->publishMessage($request);
+            echo "Base64MessagePublished! \n";
+        } catch (MnsException $e) {
+            echo "PublishBase64Message Failed: " . $e;
             return;
         }
 
         // 5. start receive message
+        // You need to decide whether to perform base64 decoding when receiving messages
+        // based on whether the messages pushed to the topic are base64 encoded.
         while (true) {
             try {
                 $res = $queue->receiveMessage(3);

--- a/Samples/Topic/TopicSubscribe.php
+++ b/Samples/Topic/TopicSubscribe.php
@@ -1,6 +1,9 @@
 <?php
 
+require_once __DIR__ . '/../Common.php';
+
 use AliyunMNS\Client;
+use AliyunMNS\Constants;
 use AliyunMNS\Model\SubscriptionAttributes;
 use AliyunMNS\Requests\PublishMessageRequest;
 use AliyunMNS\Requests\CreateTopicRequest;
@@ -166,15 +169,22 @@ class TopicSubscribe
 
 $region = "";
 $accountId ="";
-$accessId = "";
-$accessKey = "";
+$accessId = getenv(Constants::ALIYUN_AK_ENV_KEY);
+$accessKey = getenv(Constants::ALIYUN_SK_ENV_KEY);
 $endPoint = "";
 
-if (empty($region)||empty($accessId) || empty($accessKey) || empty($endPoint))
+if (empty($accessId) || empty($accessKey))
 {
-    echo "Must Provide Region/AccessId/AccessKey/EndPoint to Run the Example. \n";
+    echo "Must Set AccessId/AccessKey In Env to Run the Example. \n";
     return;
 }
+
+if (empty($endPoint) || empty($region) || empty($accountId)) {
+    echo "Must Provide EndPoint/Region/AccountId to Run the Example. \n";
+    return;
+}
+
+
 $instance = new TopicSubscribe($region, $accountId, $accessId, $accessKey, $endPoint);
 $instance->run();
 

--- a/Tests/ClientTest.php
+++ b/Tests/ClientTest.php
@@ -1,6 +1,7 @@
 <?php
 
-use AliyunMNS\Client;
+require_once __DIR__ . '/Compatibility.php';
+
 use AliyunMNS\Constants;
 use AliyunMNS\AsyncCallback;
 use AliyunMNS\Model\QueueAttributes;
@@ -11,51 +12,9 @@ use AliyunMNS\Requests\CreateQueueRequest;
 use AliyunMNS\Requests\CreateTopicRequest;
 use AliyunMNS\Requests\ListQueueRequest;
 use AliyunMNS\Requests\ListTopicRequest;
-use AliyunMNS\Requests\SetAccountAttributesRequest;
-use AliyunMNS\Requests\GetAccountAttributesRequest;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends PHPUnitBase
 {
-    private $accessId;
-    private $accessKey;
-    private $endPoint;
-    private $client;
-
-    private $queueToDelete;
-    private $topicToDelete;
-
-    public function setUp()
-    {
-        $ini_array = parse_ini_file(__DIR__ . "/aliyun-mns.ini");
-
-        $this->endPoint = $ini_array["endpoint"];
-        $this->accessId = $ini_array["accessid"];
-        $this->accessKey = $ini_array["accesskey"];
-
-        $this->queueToDelete = array();
-        $this->topicToDelete = array();
-
-        $this->client = new Client($this->endPoint, $this->accessId, $this->accessKey);
-    }
-
-    public function tearDown()
-    {
-        foreach ($this->queueToDelete as $queueName)
-        {
-            try {
-                $this->client->deleteQueue($queueName);
-            } catch (\Exception $e) {
-            }
-        }
-        foreach ($this->topicToDelete as $topicName)
-        {
-            try {
-                $this->client->deleteTopic($topicName);
-            } catch (\Exception $e) {
-            }
-        }
-    }
-
     public function testAccountAttributes()
     {
         try

--- a/Tests/Compatibility.php
+++ b/Tests/Compatibility.php
@@ -1,0 +1,22 @@
+<?php
+
+// PHPUnit 6 introduced a breaking change that removed PHPUnit_Framework_TestCase as a base class,
+// and replaced it with \PHPUnit\Framework\TestCase
+// 为满足兼容性，当使用 PHPUnit 高版本时，对新的 TestCase 创建别名
+if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase')) {
+    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
+}
+
+// 根据 PHPUnit 版本加载对应的的基础类，并设置别名。
+// 如果有新的 setUp 等动作，可以新增 Base 类，在下面设置别名并在具体的测试类中使用。
+if (class_exists('PHPUnit\Runner\Version') && version_compare(PHPUnit\Runner\Version::id(), '8.0.0', '>=')) {
+    require_once __DIR__ . "/PHPUnit8Base.php";
+    if (!class_exists('PHPUnitBase')) {
+        class_alias('PHPUnit8Base', 'PHPUnitBase');
+    }
+} else {
+    require_once __DIR__ . "/PHPUnit7Base.php";
+    if (!class_exists('PHPUnitBase')) {
+        class_alias('PHPUnit7Base', 'PHPUnitBase');
+    }
+}

--- a/Tests/PHPUnit7Base.php
+++ b/Tests/PHPUnit7Base.php
@@ -1,0 +1,42 @@
+<?php
+
+use AliyunMNS\Client;
+
+abstract class PHPUnit7Base extends \PHPUnit_Framework_TestCase
+{
+    public $client;
+    public $queueToDelete;
+    public $topicToDelete;
+
+    protected function setUp()
+    {
+        $ini_array = parse_ini_file(__DIR__ . "/aliyun-mns.ini");
+
+        $endPoint = $ini_array["endpoint"];
+        $accessId = $ini_array["accessid"];
+        $accessKey = $ini_array["accesskey"];
+
+        $this->queueToDelete = array();
+        $this->topicToDelete = array();
+
+        $this->client = new Client($endPoint, $accessId, $accessKey);
+    }
+
+    protected function tearDown()
+    {
+        foreach ($this->queueToDelete as $queueName) {
+            try {
+                $this->client->deleteQueue($queueName);
+            } catch (\Exception $e) {
+            }
+        }
+        foreach ($this->topicToDelete as $topicName) {
+            try {
+                $this->client->deleteTopic($topicName);
+            } catch (\Exception $e) {
+            }
+        }
+    }
+}
+
+?>

--- a/Tests/PHPUnit8Base.php
+++ b/Tests/PHPUnit8Base.php
@@ -1,0 +1,42 @@
+<?php
+
+use AliyunMNS\Client;
+
+abstract class PHPUnit8Base extends \PHPUnit_Framework_TestCase
+{
+    public $client;
+    public $queueToDelete;
+    public $topicToDelete;
+
+    protected function setUp(): void
+    {
+        $ini_array = parse_ini_file(__DIR__ . "/aliyun-mns.ini");
+
+        $endPoint = $ini_array["endpoint"];
+        $accessId = $ini_array["accessid"];
+        $accessKey = $ini_array["accesskey"];
+
+        $this->queueToDelete = array();
+        $this->topicToDelete = array();
+
+        $this->client = new Client($endPoint, $accessId, $accessKey);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->queueToDelete as $queueName) {
+            try {
+                $this->client->deleteQueue($queueName);
+            } catch (\Exception $e) {
+            }
+        }
+        foreach ($this->topicToDelete as $topicName) {
+            try {
+                $this->client->deleteTopic($topicName);
+            } catch (\Exception $e) {
+            }
+        }
+    }
+}
+
+?>

--- a/Tests/QueueTest.php
+++ b/Tests/QueueTest.php
@@ -1,54 +1,19 @@
 <?php
 
-use AliyunMNS\Client;
-use AliyunMNS\Constants;
-use AliyunMNS\AsyncCallback;
+require_once __DIR__ . '/Compatibility.php';
+
 use AliyunMNS\Model\QueueAttributes;
 use AliyunMNS\Exception\MnsException;
 use AliyunMNS\Exception\BatchSendFailException;
 use AliyunMNS\Exception\BatchDeleteFailException;
 use AliyunMNS\Requests\CreateQueueRequest;
-use AliyunMNS\Requests\GetQueueAttributeRequest;
-use AliyunMNS\Requests\SetQueueAttributeRequest;
 use AliyunMNS\Requests\SendMessageRequest;
 use AliyunMNS\Requests\BatchSendMessageRequest;
 use AliyunMNS\Requests\BatchReceiveMessageRequest;
-use AliyunMNS\Requests\BatchPeekMessageRequest;
 use AliyunMNS\Model\SendMessageRequestItem;
 
-class QueueTest extends \PHPUnit_Framework_TestCase
+class QueueTest extends PHPUnitBase
 {
-    private $accessId;
-    private $accessKey;
-    private $endPoint;
-    private $client;
-
-    private $queueToDelete;
-
-    public function setUp()
-    {
-        $ini_array = parse_ini_file(__DIR__ . "/aliyun-mns.ini");
-
-        $this->endPoint = $ini_array["endpoint"];
-        $this->accessId = $ini_array["accessid"];
-        $this->accessKey = $ini_array["accesskey"];
-
-        $this->queueToDelete = array();
-
-        $this->client = new Client($this->endPoint, $this->accessId, $this->accessKey);
-    }
-
-    public function tearDown()
-    {
-        foreach ($this->queueToDelete as $queueName)
-        {
-            try {
-                $this->client->deleteQueue($queueName);
-            } catch (\Exception $e) {
-            }
-        }
-    }
-
     private function prepareQueue($queueName, $attributes = NULL, $base64=TRUE)
     {
         $request = new CreateQueueRequest($queueName, $attributes);
@@ -206,12 +171,10 @@ class QueueTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue(FALSE, $e);
         }
 
-        $newReceiptHandle = NULL;
         try
         {
             $res = $queue->changeMessageVisibility($receiptHandle, 18);
             $this->assertTrue($res->isSucceed());
-            $newReceiptHandle = $res->getReceiptHandle();
         }
         catch (MnsException $e)
         {
@@ -221,16 +184,6 @@ class QueueTest extends \PHPUnit_Framework_TestCase
         try
         {
             $res = $queue->deleteMessage($receiptHandle);
-            $this->assertTrue(FALSE, "Should NOT reach here!");
-        }
-        catch (MnsException $e)
-        {
-            $this->assertEquals(Constants::MESSAGE_NOT_EXIST, $e->getMnsErrorCode());
-        }
-
-        try
-        {
-            $res = $queue->deleteMessage($newReceiptHandle);
             $this->assertTrue($res->isSucceed());
         }
         catch (MnsException $e)
@@ -283,12 +236,10 @@ class QueueTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue(FALSE, $e);
         }
 
-        $newReceiptHandle = NULL;
         try
         {
             $res = $queue->changeMessageVisibility($receiptHandle, 18);
             $this->assertTrue($res->isSucceed());
-            $newReceiptHandle = $res->getReceiptHandle();
         }
         catch (MnsException $e)
         {
@@ -298,16 +249,6 @@ class QueueTest extends \PHPUnit_Framework_TestCase
         try
         {
             $res = $queue->deleteMessage($receiptHandle);
-            $this->assertTrue(FALSE, "Should NOT reach here!");
-        }
-        catch (MnsException $e)
-        {
-            $this->assertEquals(Constants::MESSAGE_NOT_EXIST, $e->getMnsErrorCode());
-        }
-
-        try
-        {
-            $res = $queue->deleteMessage($newReceiptHandle);
             $this->assertTrue($res->isSucceed());
         }
         catch (MnsException $e)
@@ -335,7 +276,7 @@ class QueueTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($res->isSucceed());
 
             $responseItems = $res->getSendMessageResponseItems();
-            $this->assertTrue(count($responseItems) == 3);
+            $this->assertTrue(count($responseItems) == $numOfMessages);
             foreach ($responseItems as $item)
             {
                 $this->assertEquals(strtoupper($bodyMD5), $item->getMessageBodyMD5());
@@ -356,7 +297,7 @@ class QueueTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($res->isSucceed());
 
             $messages = $res->getMessages();
-            $this->assertEquals($numOfMessages, count($messages));
+            $this->assertLessThanOrEqual($numOfMessages, count($messages));
             foreach ($messages as $message)
             {
                 $this->assertEquals(strtoupper($bodyMD5), $message->getMessageBodyMD5());
@@ -375,7 +316,7 @@ class QueueTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($res->isSucceed());
 
             $messages = $res->getMessages();
-            $this->assertEquals($numOfMessages, count($messages));
+            $this->assertLessThanOrEqual($numOfMessages, count($messages));
             foreach ($messages as $message)
             {
                 $this->assertEquals(strtoupper($bodyMD5), $message->getMessageBodyMD5());
@@ -422,6 +363,7 @@ class QueueTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($res->isSucceed());
 
             $responseItems = $res->getSendMessageResponseItems();
+            $this->assertTrue(count($responseItems) == $numOfMessages);
             foreach ($responseItems as $item)
             {
                 $this->assertEquals(strtoupper($bodyMD5), $item->getMessageBodyMD5());
@@ -442,7 +384,7 @@ class QueueTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($res->isSucceed());
 
             $messages = $res->getMessages();
-            $this->assertEquals($numOfMessages, count($messages));
+            $this->assertLessThanOrEqual($numOfMessages, count($messages));
             foreach ($messages as $message)
             {
                 $this->assertEquals(strtoupper($bodyMD5), $message->getMessageBodyMD5());
@@ -461,7 +403,7 @@ class QueueTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($res->isSucceed());
 
             $messages = $res->getMessages();
-            $this->assertEquals($numOfMessages, count($messages));
+            $this->assertLessThanOrEqual($numOfMessages, count($messages));
             foreach ($messages as $message)
             {
                 $this->assertEquals(strtoupper($bodyMD5), $message->getMessageBodyMD5());

--- a/Tests/TopicTest.php
+++ b/Tests/TopicTest.php
@@ -76,7 +76,7 @@ class TopicTest extends \PHPUnit_Framework_TestCase
     {
         try
         {
-            $attributes = new SubscriptionAttributes($subscriptionName, 'http://127.0.0.1', 'BACKOFF_RETRY', 'XML');
+            $attributes = new SubscriptionAttributes($subscriptionName, 'https://www.baidu.com/', 'BACKOFF_RETRY', 'XML');
             $topic->subscribe($attributes);
         }
         catch (MnsException $e)
@@ -232,7 +232,7 @@ class TopicTest extends \PHPUnit_Framework_TestCase
             $batchSmsAttributes = new BatchSmsAttributes("陈舟锋", "SMS_15535414");
             $batchSmsAttributes->addReceiver("13735576932", array("name" => "phpsdk-batchsms"));
             $messageAttributes = new MessageAttributes(array($batchSmsAttributes));
-            $request = new PublishMessageRequest($messageBody, $messageAttributes);
+            $request = new PublishMessageRequest($messageBody, NULL, $messageAttributes);
 
             $res = $topic->publishMessage($request);
             $this->assertTrue($res->isSucceed());
@@ -268,7 +268,7 @@ class TopicTest extends \PHPUnit_Framework_TestCase
             $smsParams = array("name" => "phpsdk");
             $smsAttributes = new SmsAttributes("陈舟锋", "SMS_15535414", $smsParams, "13735576932");
             $messageAttributes = new MessageAttributes($smsAttributes);
-            $request = new PublishMessageRequest($messageBody, $messageAttributes);
+            $request = new PublishMessageRequest($messageBody, NULL, $messageAttributes);
 
             $res = $topic->publishMessage($request);
             $this->assertTrue($res->isSucceed());
@@ -303,7 +303,7 @@ class TopicTest extends \PHPUnit_Framework_TestCase
 
             $mailAttributes = new MailAttributes("TestSubject", "TestAccountName");
             $messageAttributes = new MessageAttributes($mailAttributes);
-            $request = new PublishMessageRequest($messageBody, $messageAttributes);
+            $request = new PublishMessageRequest($messageBody,NULL, $messageAttributes);
 
             $res = $topic->publishMessage($request);
             $this->assertTrue($res->isSucceed());
@@ -369,7 +369,7 @@ class TopicTest extends \PHPUnit_Framework_TestCase
         $topic = $this->prepareTopic($topicName);
 
         $subscriptionName = 'testSubscribeSubscription' . uniqid();
-        $attributes = new SubscriptionAttributes($subscriptionName, 'http://127.0.0.1', 'BACKOFF_RETRY', 'XML');
+        $attributes = new SubscriptionAttributes($subscriptionName, 'https://www.baidu.com/', 'BACKOFF_RETRY', 'XML');
         try
         {
             $topic->subscribe($attributes);

--- a/Tests/TopicTest.php
+++ b/Tests/TopicTest.php
@@ -1,60 +1,23 @@
 <?php
 
-use AliyunMNS\Client;
+require_once __DIR__ . '/Compatibility.php';
+
 use AliyunMNS\Topic;
 use AliyunMNS\Constants;
-use AliyunMNS\AsyncCallback;
 use AliyunMNS\Model\TopicAttributes;
 use AliyunMNS\Model\MailAttributes;
 use AliyunMNS\Model\SmsAttributes;
 use AliyunMNS\Model\BatchSmsAttributes;
-// use AliyunMNS\Model\WebSocketAttributes;
 use AliyunMNS\Model\MessageAttributes;
 use AliyunMNS\Model\SubscriptionAttributes;
 use AliyunMNS\Model\UpdateSubscriptionAttributes;
 use AliyunMNS\Exception\MnsException;
 use AliyunMNS\Requests\CreateQueueRequest;
 use AliyunMNS\Requests\CreateTopicRequest;
-use AliyunMNS\Requests\GetTopicAttributeRequest;
-use AliyunMNS\Requests\SetTopicAttributeRequest;
 use AliyunMNS\Requests\PublishMessageRequest;
 
-class TopicTest extends \PHPUnit_Framework_TestCase
+class TopicTest extends PHPUnitBase
 {
-    private $accessId;
-    private $accessKey;
-    private $endPoint;
-    private $client;
-
-    private $topicToDelete;
-
-    public function setUp()
-    {
-        $ini_array = parse_ini_file(__DIR__ . "/aliyun-mns.ini");
-
-        $this->endPoint = $ini_array["endpoint"];
-        $this->accessId = $ini_array["accessid"];
-        $this->accessKey = $ini_array["accesskey"];
-
-        $this->topicToDelete = array();
-
-        $this->client = new Client($this->endPoint, $this->accessId, $this->accessKey);
-    }
-
-    public function tearDown()
-    {
-        foreach ($this->topicToDelete as $topicName)
-        {
-            try
-            {
-                $this->client->deleteTopic($topicName);
-            }
-            catch (\Exception $e)
-            {
-            }
-        }
-    }
-
     private function prepareTopic($topicName, $attributes = NULL)
     {
         $request = new CreateTopicRequest($topicName, $attributes);
@@ -237,7 +200,7 @@ class TopicTest extends \PHPUnit_Framework_TestCase
             $res = $topic->publishMessage($request);
             $this->assertTrue($res->isSucceed());
             $this->assertEquals(strtoupper($bodyMD5), $res->getMessageBodyMD5());
-            echo $res->getMessageId();
+//            echo $res->getMessageId();
             sleep(5);
         }
         catch (MnsException $e)
@@ -273,7 +236,7 @@ class TopicTest extends \PHPUnit_Framework_TestCase
             $res = $topic->publishMessage($request);
             $this->assertTrue($res->isSucceed());
             $this->assertEquals(strtoupper($bodyMD5), $res->getMessageBodyMD5());
-            echo $res->getMessageId();
+//            echo $res->getMessageId();
             sleep(5);
         }
         catch (MnsException $e)
@@ -303,12 +266,12 @@ class TopicTest extends \PHPUnit_Framework_TestCase
 
             $mailAttributes = new MailAttributes("TestSubject", "TestAccountName");
             $messageAttributes = new MessageAttributes($mailAttributes);
-            $request = new PublishMessageRequest($messageBody,NULL, $messageAttributes);
+            $request = new PublishMessageRequest($messageBody, NULL, $messageAttributes);
 
             $res = $topic->publishMessage($request);
             $this->assertTrue($res->isSucceed());
             $this->assertEquals(strtoupper($bodyMD5), $res->getMessageBodyMD5());
-            echo $res->getMessageId();
+//            echo $res->getMessageId();
             sleep(5);
         }
         catch (MnsException $e)

--- a/Tests/Unit/QueueMessageBase64Test.php
+++ b/Tests/Unit/QueueMessageBase64Test.php
@@ -2,13 +2,12 @@
 
 namespace Unit;
 
+require_once __DIR__ . "/../Compatibility.php";
+
 use AliyunMNS\Requests\SendMessageRequest;
 use AliyunMNS\Responses\ReceiveMessageResponse;
 
-if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase'))
-    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
-
-class TestQueueMessageBase64 extends \PHPUnit_Framework_TestCase
+class QueueMessageBase64Test extends \PHPUnit_Framework_TestCase
 {
     public function testRawStringMessage()
     {

--- a/Tests/Unit/TestQueueMessageBase64.php
+++ b/Tests/Unit/TestQueueMessageBase64.php
@@ -5,6 +5,9 @@ namespace Unit;
 use AliyunMNS\Requests\SendMessageRequest;
 use AliyunMNS\Responses\ReceiveMessageResponse;
 
+if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase'))
+    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
+
 class TestQueueMessageBase64 extends \PHPUnit_Framework_TestCase
 {
     public function testRawStringMessage()

--- a/Tests/Unit/TestQueueMessageBase64.php
+++ b/Tests/Unit/TestQueueMessageBase64.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Unit;
+
+use AliyunMNS\Requests\SendMessageRequest;
+use AliyunMNS\Responses\ReceiveMessageResponse;
+
+class TestQueueMessageBase64 extends \PHPUnit_Framework_TestCase
+{
+    public function testRawStringMessage()
+    {
+        $messageBody = 'test 字符串';
+        // 发送时不进行 base64 编码
+        $request = new SendMessageRequest($messageBody, NULL, NULL, FALSE);
+        $xmlData = $request->generateBody();
+
+        // 借助 ReceiveMessageResponse 对发送时生成的 xml 数据进行解析
+        $response = new ReceiveMessageResponse();
+
+        // 接收时不进行 base64 解码
+        $response->setBase64(FALSE);
+        $response->parseResponse(200, $xmlData);
+
+        // 1.发送时不进行 base64 编码, 接收时不进行 base64 解码, 结果应为原字符串
+        $this->assertEquals($messageBody, $response->getMessageBody());
+
+        // 接收时进行 base64 解码
+        $response->setBase64(TRUE);
+        $response->parseResponse(200, $xmlData);
+
+        // 2.发送时不进行 base64 编码, 接收时进行 base64 解码, 结果应为乱码, 与原字符串不相等
+        $this->assertNotEquals($messageBody, $response->getMessageBody());
+    }
+
+    public function testBase64Message()
+    {
+        $messageBody = 'test 字符串';
+        // 发送时进行 base64 编码
+        $request = new SendMessageRequest($messageBody, NULL, NULL, TRUE);
+        $xmlData = $request->generateBody();
+
+        // 借助 ReceiveMessageResponse 对发送时生成的 xml 数据进行解析, 拿到原始的发送数据
+        $response = new ReceiveMessageResponse();
+
+        // 接收时不进行 base64 解码
+        $response->setBase64(FALSE);
+        $response->parseResponse(200, $xmlData);
+
+        // 3.发送时进行 base64 编码, 接收时不进行 base64 解码, 结果应为 原字符串进行 base64 编码后的字符串
+        $this->assertEquals(base64_encode($messageBody), $response->getMessageBody());
+
+        // 接收时进行 base64 解码
+        $response->setBase64(TRUE);
+        $response->parseResponse(200, $xmlData);
+
+        // 4.发送时进行 base64 编码, 接收时进行 base64 解码, 结果应为原字符串
+        $this->assertEquals($messageBody, $response->getMessageBody());
+    }
+
+}

--- a/Tests/Unit/TestTopicMessageBase64.php
+++ b/Tests/Unit/TestTopicMessageBase64.php
@@ -5,6 +5,9 @@ namespace Unit;
 use AliyunMNS\Requests\PublishBase64MessageRequest;
 use AliyunMNS\Requests\PublishMessageRequest;
 
+if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase'))
+    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
+
 class TestTopicMessageBase64 extends \PHPUnit_Framework_TestCase
 {
     public function testRawStringMessage()

--- a/Tests/Unit/TestTopicMessageBase64.php
+++ b/Tests/Unit/TestTopicMessageBase64.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Unit;
+
+use AliyunMNS\Requests\PublishBase64MessageRequest;
+use AliyunMNS\Requests\PublishMessageRequest;
+
+class TestTopicMessageBase64 extends \PHPUnit_Framework_TestCase
+{
+    public function testRawStringMessage()
+    {
+        $messageBody = 'test 字符串';
+        $request = new PublishMessageRequest($messageBody);
+
+        $this->assertEquals($messageBody, $request->getMessageBody());
+    }
+
+    public function testBase64Message()
+    {
+        $messageBody = 'test 字符串';
+        $request = new PublishBase64MessageRequest($messageBody);
+
+        $this->assertEquals(base64_encode($messageBody), $request->getMessageBody());
+    }
+
+}

--- a/Tests/Unit/TopicMessageBase64Test.php
+++ b/Tests/Unit/TopicMessageBase64Test.php
@@ -2,13 +2,12 @@
 
 namespace Unit;
 
+require_once __DIR__ . "/../Compatibility.php";
+
 use AliyunMNS\Requests\PublishBase64MessageRequest;
 use AliyunMNS\Requests\PublishMessageRequest;
 
-if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase'))
-    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
-
-class TestTopicMessageBase64 extends \PHPUnit_Framework_TestCase
+class TopicMessageBase64Test extends \PHPUnit_Framework_TestCase
 {
     public function testRawStringMessage()
     {

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,12 @@
+<?php
+
+function classLoader($class)
+{
+    $path = str_replace('\\', DIRECTORY_SEPARATOR, $class);
+    $file = __DIR__ . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . $path . '.php';
+    if (file_exists($file)) {
+        require_once $file;
+    }
+}
+
+spl_autoload_register('classLoader');

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "aliyun/aliyun-mns-php-sdk",
+    "version": "1.3.7",
     "type": "library",
     "description": "Aliyun Message and Notification Service SDK for PHP, PHP>=5.5.0",
     "keywords": ["Aliyun", "mns", "MNS", "Message", "Message Service", "Notification"],
@@ -14,10 +15,13 @@
         "psr/http-message": "^1.0",
         "guzzlehttp/guzzle": ">=6.0.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "*"
+    },
     "repositories": {
         "packagist": {
             "type": "composer",
-            "url": "https://packagist.phpcomposer.com"
+            "url": "https://mirrors.aliyun.com/composer/"
         }
     },
     "autoload":{

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true"
+         stopOnFailure="false"
+         cacheResult="false">
+
+    <!-- 定义用于测试的目录 -->
+    <testsuites>
+        <testsuite name="Tests">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>


### PR DESCRIPTION
# 概述
本次代码变更主要目的是更新和优化阿里云 MNS（Message Service）PHP SDK，以提高其稳定性和兼容性。

# 变更点

1. 引入新功能：主题模型支持以 base64 编码方式发布消息。
2. 修复问题：修复 agent 上报版本问题，guzzle 依赖与 PHP 版本不兼容问题，异常处理中未定义属性及存在的动态属性问题。
3. 样例重构：推荐通过环境变量使用 ak/sk，遵循规范，避免硬编码。
4. 依赖管理更新：更新 composer 文件，加入版本号及单元测试依赖。
5. 测试用例更新：更新了测试用例以适应代码变动，并增加新功能点的单元测试。

这些变更旨在提高 SDK 的质量和用户体验，同时确保与阿里云 MNS 服务的最佳集成。